### PR TITLE
Fix a typo in the casting example

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
  * There shouldn't be a space between a cast and the variable being cast.
 
 ``` objc
-NewType a = (OldType)b;
+NewType a = (NewType)b;
 ```
 
 ## Control Structures


### PR DESCRIPTION
Doesn't make sense to assign a casted `(OldType)` to a `NewType` variable.

CC @joshaber
