### PR TITLE
Constructor return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 void GHAwesomeFunction(BOOL hasSomeArgs);
 ```
 
- * Constructors should return `instancetype` rather than `id`.
+ * Constructors should generally return `instancetype` rather than `id`.
 
 ## Expressions
 


### PR DESCRIPTION
Constructors should use `instancetype` instead of `id` as their return type because methods that do not begin with one of the checked keywords (`alloc`, `init`, `new`, etc) will not get the same stricter type checking.

See http://clang.llvm.org/docs/LanguageExtensions.html#objc_instancetype
