### PR TITLE
Proposal: specify that all immutable object properties should be marked "copy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
  * Prefer exposing an immutable type for a property if it being mutable is an implementation detail. This is a valid reason to declare an ivar for a property.
  * Always declare memory-management semantics even on `readonly` properties.
  * Declare properties `readonly` if they are only set once in `-init`.
+ * Declare properties `copy` if they return immutable objects and aren't ever mutated in the implementation.
  * Don't use `@synthesize` unless the compiler requires it. Note that optional properties in protocols must be explicitly synthesized in order to exist.
  * Instance variables should be prefixed with an underscore (just like when implicitly synthesized).
  * Don't put a space between an object type and the protocol it conforms to.


### PR DESCRIPTION
From discussion on libgit2/objective-git#103.

[Rendered Markdown](https://github.com/github/objective-c-conventions/blob/copy-properties/README.md#declarations)
