### PR TITLE
C99 Struct Initialisers

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,11 @@ void GHAwesomeFunction(BOOL hasSomeArgs);
 ```
 
  * Constructors should generally return `instancetype` rather than `id`.
- * Prefer C99 struct initialiser syntax to helper functions.
+ * Prefer C99 struct initialiser syntax to helper functions (such as `CGRectMake()`).
 
 ```objc
-CGRect rect = { .origin.x = 3.0, .origin.y = 12.0, .size.width = 15.0, .size.height = 80.0 };
-
-// rather than
-
-CGRect rect = CGRectMake(3.0, 12.0, 15.0, 80.0);
-```
+  CGRect rect = { .origin.x = 3.0, .origin.y = 12.0, .size.width = 15.0, size.height = 80.0 };
+   ```
 
 ## Expressions
 


### PR DESCRIPTION
Document a preference for verbose struct initialisers rather than helper functions. These are easier to read and allow structs to be initialise with any sub-structs rather than having to use their members explicitly.
