### PR TITLE
Proposed number style

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ id (^blockName2)(id) = ^ id (id args) {
 
 ## Literals
 
+ * Avoid making numbers a specific type unless necessary (for example, prefer `5` to `5.0`, and `5.3` to `5.3f`).
  * The contents of array and dictionary literals should have a space on both sides.
  * Dictionary literals should have no space between the key and the colon, and a single space between colon and value.
 


### PR DESCRIPTION
This has come up a few times.

I generally think any unnecessary type in a number literal is silly, because it just makes it more fragile and more work to change later (if the type of the variable, constant, etc. changes). I also prefer reading this:

``` objc
CGRect rect = { .x = 5, .y = 10, .width = 50, .height = 50 };
```

over this:

``` objc
CGRect rect = { .x = 5.0, .y = 10.0, .width = 50.0, .height = 50.0 };
```

And I think we can all agree that @alanjrogers' `5.` is horrific. :wink: 
