### PR TITLE
Variable/property naming style

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ void GHAwesomeFunction(BOOL hasSomeArgs);
 ```
 
  * Constructors should generally return `instancetype` rather than `id`.
- * Variable names should be camel-cased.
+ * Variable and property names should be camel-cased. Avoid using acronyms and abbreviations.
 
 ## Expressions
 


### PR DESCRIPTION
Variable and property names should begin with a lowercase letter and then proceed by uppercasing the first letter of each additional word (camel-case). Avoid acronyms and abbreviations.
