### PR TITLE
Block arguments should always be named.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ if (something == nil) {
  * Blocks should have a space between their return type and name.
  * Block definitions should omit their return type when possible.
  * Block definitions should omit their arguments if they are `void`.
- * Block definitions should always include argument names.
+ * Parameters in block types should be named unless the block is initialized immediately.
 
 ```objc
 void (^blockName1)(void) = ^{


### PR DESCRIPTION
Block declaration arguments should always include variable names to follow the Objective-C style of named arguments.

Also what's your stance on typedef'ing blocks? I'm somewhat against it just because you can't easily determine the block arguments by command-clicking on a method or quickly looking at a header file.
