### PR TITLE
Always declare private methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Unless explicitly contradicted below, assume that all of Apple's guidelines appl
  * Don't use `@synthesize` unless the compiler requires it. Note that optional properties in protocols must be explicitly synthesized in order to exist.
  * Instance variables should be prefixed with an underscore (just like when implicitly synthesized).
  * Don't put a space between an object type and the protocol it conforms to.
+ * Always declare private methods in a class extension.
  
 ```objc
 @property (attributes) id<Protocol> object;


### PR DESCRIPTION
Recent versions of Xcode include some changes to the compiler that make it possible to invoke methods in an implementation regardless of if they are declared and regardless of the method definition order.

When I'm reading an implementation that I'm unfamiliar with the first thing I do is check the private class extension at the top of the implementation file. While it's no longer required, I feel that the benefits of having all of your methods in one place is worth it. It helps avoid leaving around abandoned methods and avoids having to initially scan through the entire implementation. Plus you can put all of your private method docs in one place.
