### PR TITLE
Clarify when strong properties should be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Unless explicitly contradicted below, assume that all of Apple's guidelines appl
  * Prefer exposing an immutable type for a property if it being mutable is an implementation detail. This is a valid reason to declare an ivar for a property.
  * Always declare memory-management semantics even on `readonly` properties.
  * Declare properties `readonly` if they are only set once in `-init`.
- * Declare properties `copy` if they return immutable objects and aren't ever mutated in the implementation. `strong` should only be used when exposing a mutable object or an object that does not conform to the `NSCopying` protocol as a property.
  * Don't use `@synthesize` unless the compiler requires it. Note that optional properties in protocols must be explicitly synthesized in order to exist.
+ * Declare properties `copy` if they return immutable objects and aren't ever mutated in the implementation. `strong` should only be used when exposing a mutable object, or an object that does not conform to `<NSCopying>`.
  * Instance variables should be prefixed with an underscore (just like when implicitly synthesized).
  * Don't put a space between an object type and the protocol it conforms to.
  


### PR DESCRIPTION
It wasn't clear to me that the conventions were recommending only using `strong` for mutable properties, so I made it more explicit.
