### PR TITLE
Stop documenting when parameters disallow nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Unless explicitly contradicted below, assume that all of Apple's guidelines appl
  * All method declarations should be documented.
  * Comments should be hard-wrapped at 80 characters.
  * Comments should be [Tomdoc](http://tomdoc.org/)-style.
- * Document whether object parameters allow `nil` as a value.
+ * Document parameters that allow `nil` as a value. If a parameter does _not_ allow `nil`, nothing needs to be said.
  * Use `#pragma mark`s to categorize methods into functional groupings and protocol implementations, following this general structure:
 
 ```objc


### PR DESCRIPTION
Suggested by @tiennou in some [objective-git](https://github.com/libgit2/objective-git) pull request.

[Rendered Markdown](https://github.com/github/objective-c-conventions/tree/jspahrsummers-patch-1#documentation-and-organization)
