### PR TITLE
instancetype in constructor instead of id for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Unless explicitly contradicted below, assume that all of Apple's guidelines appl
 
 #pragma mark Lifecycle
 
-+ (id)objectWithThing:(id)thing {}
-- (id)init {}
++ (instancetype)objectWithThing:(id)thing {}
+- (instancetype)init {}
 
 #pragma mark Drawing
 


### PR DESCRIPTION
In the declaration conventions, one of the rule says "Constructors should generally return instancetype rather than id" so perhaps the initializer example in `#pragma mark Lifecyle` should use `instancetype` instead of `id` for consistency.
