### PR TITLE
Don’t leave trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Unless explicitly contradicted below, assume that all of Apple's guidelines appl
  * Tabs, not spaces.
  * End files with a newline.
  * Make liberal use of vertical whitespace to divide code into logical chunks.
+ * Don’t leave trailing whitespace.
+    * Not even leading indentation on blank lines.
 
 ## Documentation and Organization
 
@@ -57,12 +59,12 @@ Unless explicitly contradicted below, assume that all of Apple's guidelines appl
  * Declare properties `copy` if they return immutable objects and aren't ever mutated in the implementation. `strong` should only be used when exposing a mutable object, or an object that does not conform to `<NSCopying>`.
  * Instance variables should be prefixed with an underscore (just like when implicitly synthesized).
  * Don't put a space between an object type and the protocol it conforms to.
- 
+
 ```objc
 @property (attributes) id<Protocol> object;
 @property (nonatomic, strong) NSObject<Protocol> *object;
 ```
- 
+
  * C function declarations should have no space before the opening parenthesis, and should be namespaced just like a class.
 
 ```objc
@@ -108,7 +110,7 @@ for (int i = 0; i < 10; i++) {
 
 ## Control Structures
 
- * Always surround `if` bodies with curly braces if there is an `else`. Single-line `if` bodies without an `else` should be on the same line as the `if`. 
+ * Always surround `if` bodies with curly braces if there is an `else`. Single-line `if` bodies without an `else` should be on the same line as the `if`.
  * All curly braces should begin on the same line as their associated statement. They should end on a new line.
  * Put a single space after keywords and before their parentheses.
  * Return and break early.


### PR DESCRIPTION
This is intended to be a descriptive, rather than prescriptive change; several of us appear to have our editors configured to strip trailing whitespace, and since I’m sick of seeing whitespace changes in diffs, I suggest we standardize.

I committed (and pushed!) this straight to `master` initially, suspiciously like an idiot might, hence why the commit here is a revert of a revert.
